### PR TITLE
fix gcc version problems

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,15 +21,14 @@ osx: &osx
    language: generic
 matrix:
    include:
-
       - <<: *linux
         env: CONAN_GCC_VERSIONS=4.9 CONAN_DOCKER_IMAGE=lasote/conangcc49
       - <<: *linux
-        env: CONAN_GCC_VERSIONS=5.4 CONAN_DOCKER_IMAGE=lasote/conangcc54
+        env: CONAN_GCC_VERSIONS=5 CONAN_DOCKER_IMAGE=lasote/conangcc5
       - <<: *linux
-        env: CONAN_GCC_VERSIONS=6.3 CONAN_DOCKER_IMAGE=lasote/conangcc63
+        env: CONAN_GCC_VERSIONS=6 CONAN_DOCKER_IMAGE=lasote/conangcc6
       - <<: *linux
-        env: CONAN_GCC_VERSIONS=7.2 CONAN_DOCKER_IMAGE=lasote/conangcc72
+        env: CONAN_GCC_VERSIONS=7 CONAN_DOCKER_IMAGE=lasote/conangcc7
       - <<: *linux
         env: CONAN_CLANG_VERSIONS=3.9 CONAN_DOCKER_IMAGE=lasote/conanclang39
       - <<: *linux


### PR DESCRIPTION
Thanks to the solution from  @tonka300 . I'm trying to fix the problem that caused by GCC version. 

GTest build error on vs2017 is a big problem that influences me a lot. (some packages cannot pass on windows because GTest build error - -! ) This way maybe not elegant but is practical. 

Hope the problem be solved as soon as possible. Thanks~